### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Download the jar file from the latest [release](https://github.com/krujos/willit
 and push it
 
 ```
-➜ cf push -p willitconnect-0.0.1.jar #Use the right version # from the release
+➜ cf push -p willitconnect-0.0.1.jar APP_NAME #Use the right version # from the release
 ```
 
 ## From source


### PR DESCRIPTION
The current CLI version (6.26.0+9c9a261.2017-04-06) seems to require an APP_NAME to be provided when pushing a JAR file.