### PR TITLE
Fix proxy type comparison and add test

### DIFF
--- a/src/main/java/willitconnect/service/util/Connection.java
+++ b/src/main/java/willitconnect/service/util/Connection.java
@@ -32,7 +32,8 @@ public class Connection {
             String host, int port, String proxyHost, int proxyPort,
             String proxyType) {
         logHost(host, port);
-        if ("http" != proxyType ) {
+        String sanitizedProxyType = proxyType == null ? null : proxyType.trim();
+        if (!"http".equalsIgnoreCase(sanitizedProxyType)) {
             throw new IllegalArgumentException("Proxy type must be http");
         }
         try {

--- a/src/test/java/willitconnect/service/util/ConnectionTest.java
+++ b/src/test/java/willitconnect/service/util/ConnectionTest.java
@@ -1,0 +1,20 @@
+package willitconnect.service.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class ConnectionTest {
+
+    @Test
+    public void checkProxyConnectionAllowsNonInternedHttpProxyType() {
+        String nonInternedHttp = new String("http");
+
+        boolean canConnect = Connection.checkProxyConnection(
+                "example.invalid", 80,
+                "proxy.invalid", 8080,
+                nonInternedHttp);
+
+        assertFalse("Connection attempt should fail without throwing due to proxy type", canConnect);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize proxy type input and compare case-insensitively before enforcing HTTP proxies
- add a util Connection test that exercises checkProxyConnection with a non-interned http string

## Testing
- ./gradlew test *(fails: gradle wrapper download blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d4283c3dd8832a8cf7d3dbf1668a58